### PR TITLE
Implemented process waiting with retries

### DIFF
--- a/src/Spork/Fork.php
+++ b/src/Spork/Fork.php
@@ -53,8 +53,14 @@ class Fork implements DeferredInterface
             return $this;
         }
 
-        if (-1 === $pid = pcntl_waitpid($this->pid, $status, ($hang ? 0 : WNOHANG) | WUNTRACED)) {
-            throw new ProcessControlException('Error while waiting for process '.$this->pid);
+        $retriesLimit = 100;
+        $retriesCounter = 0;
+        while (-1 === $pid = pcntl_waitpid($this->pid, $status, ($hang ? 0 : WNOHANG) | WUNTRACED)) {
+            if ($retriesCounter > $retriesLimit) {
+                throw new ProcessControlException('Error while waiting for process '.$this->pid);
+            }
+            ++$retriesCounter;
+            usleep(5000);
         }
 
         if ($this->pid === $pid) {


### PR DESCRIPTION
pcntl_waitpid may return -1 on temporary errors, so performing additional retries might result in successful execution.
