### PR TITLE
Implemented fifo opening with retries.

### DIFF
--- a/src/Spork/Fifo.php
+++ b/src/Spork/Fifo.php
@@ -41,7 +41,19 @@ class Fifo
                 throw new ProcessControlException(sprintf('Error while creating FIFO: %s (%d)', posix_strerror($error), $error));
             }
 
-            $this->$mode = fopen($fifo, $mode[0]);
+            $retriesLimit = 10;
+            $retriesCounter = 0;
+            while (($this->$mode = fopen($fifo, $mode[0])) === false) {
+                if ($retriesCounter > $retriesLimit) {
+                    throw new ProcessControlException(sprintf(
+                        'Error while opening file %s in mode %s',
+                        $fifo,
+                        $mode[0]
+                    ));
+                }
+                ++$retriesCounter;
+                usleep(1000);
+            }
         }
     }
 


### PR DESCRIPTION
fopen may fail temporarily (e.g. "failed to open stream: Interrupted system call" when there are 30+ forks).
It's critical to handle fifo opening errors because of blocking read in child. Child is waiting forever if no parent connects.
