### PR TITLE
Allow passing parameters for callback when forking.

### DIFF
--- a/src/Spork/ProcessManager.php
+++ b/src/Spork/ProcessManager.php
@@ -99,7 +99,7 @@ class ProcessManager
             $fifo = new Fifo();
 
             $arguments = func_get_args();
-            $arguments[0] = $fifo;
+            $arguments[] = $fifo;
 
             // dispatch an event so the system knows it's in a new process
             $this->dispatcher->dispatch(Events::POST_FORK);
@@ -107,7 +107,7 @@ class ProcessManager
             ob_start();
 
             try {
-                $result = call_user_func_array($callable, $arguments);
+                $result = call_user_func_array($callable, array_slice($arguments, 1));
                 $exitStatus = is_integer($result) ? $result : 0;
                 $error = null;
             } catch (\Exception $e) {

--- a/tests/Spork/Test/ProcessManagerTest.php
+++ b/tests/Spork/Test/ProcessManagerTest.php
@@ -50,7 +50,7 @@ class ProcessManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testForkWithArguments()
     {
-        $fork = $this->manager->fork(function ($fifo, $argument) {
+        $fork = $this->manager->fork(function ($argument, $fifo) {
             return $argument;
         }, 'hello');
 


### PR DESCRIPTION
This allows for cleaner code in someplaces where you would otherwise have to use a closure, which can be hard to test.

My use case.

I have a class with a method where i want to fork out, that method takes one argument like

``` php
<?php

function doSomethingExciting($myLuckyNumber) {
    // do something here
}
```

 Currently i would have to do something like

``` php
<?

$lucky = 42;

$manager = new Spork\ProcessManager;
$manager->fork(function ($fifo) use ($lucky) {
    doSomethingExiting($lucky);
});
```

Instead of

``` php
<?php

function doSomethingExciting($lucky, $optionalFifo) {
}

$manager = new Sprok\ProcessManager;
$manager->fork('doSomethingExciting', $lucky);
```
