### PR TITLE
Fixed potential wrong $limit parameter in the child cursor if a $limit i...

### DIFF
--- a/src/Spork/Batch/Strategy/MongoStrategy.php
+++ b/src/Spork/Batch/Strategy/MongoStrategy.php
@@ -49,7 +49,7 @@ class MongoStrategy extends AbstractStrategy
         }
 
         $skip  = $this->skip;
-        $limit = ceil(($cursor->count() - $skip) / $this->size);
+        $limit = ceil(($cursor->count(true) - $skip) / $this->size);
 
         $batches = array();
         for ($i = 0; $i < $this->size; $i++) {


### PR DESCRIPTION
Fixed potential wrong $limit parameter in the child cursor if a $limit is provided to the parent.

A problem occured when i passed a cursor with a defined limit.

``` php
// Parent cursor with a limit
$items = $documentManager->getRepository('...')->findBy(array())->limit(50);

$self = $this;
$this->spork->process(
    $items,
    function($item, $index, $batch, $fifo) use ($self) {
        $self->process($item);
    },
    new DoctrineMongoStrategy(2)
);
```

And i would like to have the following forks:
[0-25[
[25-50[

Thanks for this very useful library !
