### PR TITLE
Let application handle when extension is not available

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,11 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "ext-pcntl": "*",
-        "ext-posix": "*",
         "symfony/event-dispatcher": "*"
+    },
+    "require-dev": {
+        "ext-pcntl": "*",
+        "ext-posix": "*"
     },
     "autoload": {
         "psr-0": { "Spork": "src/" }


### PR DESCRIPTION
The extension should be checked only for this library development.

Example:
Developer cannot identify that user use Windows/or/unix based

However, this package have to be added as "require" package so, it will always failed to install on Windows.

I think it better to let developer who use this library decide what is the behavior more then fail to install the application because extension is missing.

Because developer may let Unix user with extension can run with parallel processing while windows still be able to run as serial processing.
