### PR TITLE
Fix erroneous exit code not propagating for BatchJob

### DIFF
--- a/src/Spork/Batch/BatchJob.php
+++ b/src/Spork/Batch/BatchJob.php
@@ -93,11 +93,17 @@ class BatchJob
 
         $results = array();
         foreach ($forks as $fork) {
+
             $exitStatus = $fork->getExitStatus();
             if (0 !== $exitStatus) {
-                // Propagate erroneous state
-                exit($exitStatus);
+                if ($error = $fork->getError()) {
+                    // Unfortunately the original exception is lost and Error is not throwable
+                    throw new \RuntimeException($error->getMessage());
+                }
+
+                return $exitStatus;
             }
+
             $results = array_merge($results, (array) $fork->getResult());
         }
 

--- a/src/Spork/Batch/BatchJob.php
+++ b/src/Spork/Batch/BatchJob.php
@@ -93,7 +93,12 @@ class BatchJob
 
         $results = array();
         foreach ($forks as $fork) {
-            $results = array_merge($results, $fork->getResult());
+            $exitStatus = $fork->getExitStatus();
+            if (0 !== $exitStatus) {
+                // Propagate erroneous state
+                exit($exitStatus);
+            }
+            $results = array_merge($results, (array) $fork->getResult());
         }
 
         return $results;

--- a/tests/Spork/Test/Batch/BatchJobTest.php
+++ b/tests/Spork/Test/Batch/BatchJobTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Spork\Test\Batch;
+
+class BatchJobTest extends \PHPUnit_Framework_TestCase
+{
+    public function testErrorPropagation()
+    {
+        $manager = new \Spork\ProcessManager();
+        $batch = $manager->createBatchJob(range(1, 5));
+
+        $expectedExitStatus = 20;
+
+        $failingClosure = function ($data) use ($expectedExitStatus) {
+            // Simple condition to simulate only one point of failure
+            if (3 === $data) {
+                exit($expectedExitStatus);
+            }
+
+            exit(0);
+        };
+
+        $promise = $batch->execute($failingClosure);
+
+        $promise->wait();
+
+        $success = null;
+
+        $promise->done(function () use (& $success) {
+            $success = true;
+        });
+
+        $promise->fail(function () use (& $success) {
+            $success = false;
+        });
+
+        $this->assertFalse($success, 'Promise should fail');
+
+        $actualExitStatus = $promise->getExitStatus();
+
+        $this->assertEquals($expectedExitStatus, $actualExitStatus, 'Parent process exit status should match the child one');
+    }
+
+    public function testExitStatusIsZeroOnSuccess()
+    {
+        $manager = new \Spork\ProcessManager();
+        $batch = $manager->createBatchJob(range(1, 5));
+
+        $simpleClosure = function () {
+            exit(0);
+        };
+
+        $promise = $batch->execute($simpleClosure);
+
+        $promise->wait();
+
+        $success = null;
+
+        $promise->done(function () use (& $success) {
+            $success = true;
+        });
+
+        $promise->fail(function () use (& $success) {
+            $success = false;
+        });
+
+        $this->assertTrue($success, 'Promise should be successful');
+
+        $actualExitStatus = $promise->getExitStatus();
+
+        $this->assertEquals(0, $actualExitStatus, 'When the promise is successful the exit status should be zero');
+    }
+}


### PR DESCRIPTION
BatchJob was not correctly propagating erroneous exit codes of its child processes.

If you are looking for bug replication this commit is useful https://github.com/taueres/spork/commit/748dabd4485ad5c90c51c146f2dc33e7789d3f91 (Dockerfile included).
