### PR TITLE
Add PHP 5.6 and PHP 7 to Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ php:
     - 5.3
     - 5.4
     - 5.5
+    - 5.6
+    - 7
+
+matrix:
+    allow_failures:
+        - php: 7
 
 before_script:
     - wget http://getcomposer.org/composer.phar


### PR DESCRIPTION
Builds on PHP 7 are allowed to fail since that version is not stable yet.
