### PR TITLE
[EventDispatcher]: implement remaining method from BaseEventDispatcherrInterface

### DIFF
--- a/src/Spork/EventDispatcher/WrappedEventDispatcher.php
+++ b/src/Spork/EventDispatcher/WrappedEventDispatcher.php
@@ -76,4 +76,9 @@ class WrappedEventDispatcher implements EventDispatcherInterface
     {
         return $this->delegate->hasListeners($eventName);
     }
+
+    public function getListenerPriority($eventName, $listener)
+    {
+        return $this->delegate->getListenerPriority($eventName, $listener);
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | np |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets |  |

When updating to symfony 3, the interface Symfony\Component\EventDispatcher\EventDispatcherInterface has  a new method implemented.  

Therefore we need to implement it to.
