### PR TITLE
Fixed shared memory writing and fork losing received messages

### DIFF
--- a/src/Spork/Fork.php
+++ b/src/Spork/Fork.php
@@ -26,6 +26,7 @@ class Fork implements DeferredInterface
     private $name;
     private $status;
     private $message;
+    private $messages = array();
 
     public function __construct($pid, SharedMemory $shm, $debug = false)
     {
@@ -92,17 +93,15 @@ class Fork implements DeferredInterface
 
     public function receive()
     {
-        $messages = array();
-
         foreach ($this->shm->receive() as $message) {
             if ($message instanceof ExitMessage) {
                 $this->message = $message;
             } else {
-                $messages[] = $message;
+                $this->messages[] = $message;
             }
         }
 
-        return $messages;
+        return $this->messages;
     }
 
     public function kill($signal = SIGINT)
@@ -133,6 +132,11 @@ class Fork implements DeferredInterface
         if ($this->message) {
             return $this->message->getError();
         }
+    }
+
+    public function getMessages()
+    {
+        return $this->messages;
     }
 
     public function isSuccessful()

--- a/src/Spork/SharedMemory.php
+++ b/src/Spork/SharedMemory.php
@@ -76,7 +76,7 @@ class SharedMemory
         if (($shmId = @shmop_open($this->pid, 'a', 0, 0)) > 0) {
             // Read any existing messages in shared memory
             $readMessage = shmop_read($shmId, 0, shmop_size($shmId));
-            $messageArray[] = unserialize($readMessage);
+            $messageArray = unserialize($readMessage);
             shmop_delete($shmId);
             shmop_close($shmId);
         }


### PR DESCRIPTION
Two issues fixed:
1. The Fork was losing received messages. When waiting it does a ::receive and does nothing with the result. The fix was to add a messages collection to the form and have the ::receive populate that collection. This way messages can be retrieved at any time using ::getMessages.
2. Shared memory was creating imbricated arrays with each ::send making the Fork::receive end up with array in array in array, etc. instead of a flat array of messages.
